### PR TITLE
Assorted fixes

### DIFF
--- a/test/ustring/test_stxcmp.c
+++ b/test/ustring/test_stxcmp.c
@@ -53,6 +53,17 @@ TEST_DEFINE(stxcmp_same_str)
 	TEST_END;
 }
 
+TEST_DEFINE(stxcmp_mostly_same_str)
+{
+	stx str1, str2;
+	stxdup_str(&str1, "hellosame_bob_backtothesame");
+	stxdup_str(&str2, "hellosame_jim_backtothesame");
+
+	TEST_ASSERT(false == stxcmp(stxr(str1), stxr(str2)));
+
+	TEST_END;
+}
+
 TEST_DEFINE(stxcmp_diff_bytes)
 {
 	stx s1 = {
@@ -132,5 +143,6 @@ main(void)
 	TEST_RUN(ts, stxcmp_diff_bytes);
 	TEST_RUN(ts, stxcmp_same_bytes);
 	TEST_RUN(ts, stxcmp_aligned_bytes);
+	TEST_RUN(ts, stxcmp_mostly_same_str);
 	TEST_PRINT(ts);
 }

--- a/test/ustring/test_stxcmp.c
+++ b/test/ustring/test_stxcmp.c
@@ -72,7 +72,13 @@ TEST_DEFINE(stxcmp_diff_bytes)
 		.mem = rb1,
 	};
 
-	TEST_ASSERT(true == stxcmp(stxr(s1), stxr(s1)));
+	stx s2 = {
+		.len = strlen(rb2),
+		.size = sizeof(rb2),
+		.mem = rb2,
+	};
+
+	TEST_ASSERT(false == stxcmp(stxr(s1), stxr(s2)));
 
 	TEST_END;
 }

--- a/ustring/ustr_ensure_size.c
+++ b/ustring/ustr_ensure_size.c
@@ -8,14 +8,12 @@ ustr_ensure_size(Ustring *sp, size_t n)
 
 	if (sp->size >= n)
 		return 0;
-	if (!sp->mem && !n) {
-		memset(sp, 0, sizeof(*sp));
-	} else {
-		tmp = realloc(sp->mem, n);
-		if (!tmp)
-			return -1;
-		sp->mem = tmp;
-		sp->size = n;
-	}
+
+	tmp = realloc(sp->mem, n);
+	if (!tmp)
+		return -1;
+	sp->mem = tmp;
+	sp->size = n;
+
 	return 0;
 }

--- a/ustring/ustr_eq.c
+++ b/ustring/ustr_eq.c
@@ -12,7 +12,7 @@ ustr_eq(Ustr const *s1, Ustr const *s2)
 	/* Compare chunks of register size for speed */
 	const size_t chunks = s1->len / sizeof(i);
 	for (i = 0; i < chunks; ++i) {
-		if (*(size_t *)s1->mem + i != *(size_t *)s2->mem + i)
+		if (*((size_t *)s1->mem + i) != *((size_t *)s2->mem + i))
 			return false;
 	}
 	/* Compare the leftover bytes */


### PR DESCRIPTION
PVS studio led me to some interesting bugs, and I noticed one of the test cases was incorrect as a result of a copy paste oversight. 

- Fixed stxcmp. Previously, it was adding i after it was dereferenced, not to the pointer before it was dereferenced. Functionally, this meant that it was only checking the first chunk over and over again. You can see the test I added for an example of this.
- Removed a case that could never be hit in stxensuresize. That case depends on n being zero, but if n was zero we already would have returned zero because of the last conditional. If you still want that memset logic to be preserved, the check will have to be moved to before the first conditional. Let me know how you want that to be handled, and I'll change it if needed. I wasn't sure what the point of that memset was, so I'm probably missing something there.
- Fixed the stxcmp_diff_bytes test, as prior it was just a duplicate of the same bytes test (I assume copy paste error.)

Thanks for your work on this library!